### PR TITLE
Change language of default config location in configuration.md

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -11,8 +11,7 @@ environment variable (e.g. `export MADONCTL_INSTANCE='https://mamot.fr'`).
 
 ## Configuration file
 
-The configuration file is usually located in the `$HOME/.config/madonctl`
-directory.
+The default configuration file is located at `$HOME/.config/madonctl/madonctl.yaml`.
 
 We use [viper](http://spf13.com/project/viper), so you can use the format you
 prefer between YAML, TOML or JSON.  The examples use the YAML format so the


### PR DESCRIPTION
Update the configuration instructions to match the --config
option default location

I was a bit confused with where to place the default config file and thought
this might help since it matches the default for the --config flag