### PR TITLE
Update to handle non-int64 IDs

### DIFF
--- a/cmd/domainblocks.go
+++ b/cmd/domainblocks.go
@@ -17,9 +17,9 @@ import (
 var domainBlocksOpts struct {
 	show, block, unblock bool
 
-	limit          uint  // Limit the results
-	sinceID, maxID int64 // Query boundaries
-	all            bool  // Try to fetch all results
+	limit          uint              // Limit the results
+	sinceID, maxID madon.ActivityID // Query boundaries
+	all            bool              // Try to fetch all results
 }
 
 // timelinesCmd represents the timelines command
@@ -41,8 +41,8 @@ func init() {
 	domainBlocksCmd.Flags().BoolVar(&domainBlocksOpts.unblock, "unblock", false, "Unblock domain")
 
 	domainBlocksCmd.Flags().UintVarP(&domainBlocksOpts.limit, "limit", "l", 0, "Limit number of results")
-	domainBlocksCmd.Flags().Int64Var(&domainBlocksOpts.sinceID, "since-id", 0, "Request IDs greater than a value")
-	domainBlocksCmd.Flags().Int64Var(&domainBlocksOpts.maxID, "max-id", 0, "Request IDs less (or equal) than a value")
+	domainBlocksCmd.Flags().StringVar(&domainBlocksOpts.sinceID, "since-id", "", "Request IDs greater than a value")
+	domainBlocksCmd.Flags().StringVar(&domainBlocksOpts.maxID, "max-id", "", "Request IDs less (or equal) than a value")
 	domainBlocksCmd.Flags().BoolVar(&domainBlocksOpts.all, "all", false, "Fetch all results")
 }
 
@@ -71,17 +71,17 @@ func domainBlocksRunE(cmd *cobra.Command, args []string) error {
 
 	// Set up LimitParams
 	var limOpts *madon.LimitParams
-	if opt.all || opt.limit > 0 || opt.sinceID > 0 || opt.maxID > 0 {
+	if opt.all || opt.limit > 0 || opt.sinceID != "" || opt.maxID != "" {
 		limOpts = new(madon.LimitParams)
 		limOpts.All = opt.all
 	}
 	if opt.limit > 0 {
 		limOpts.Limit = int(opt.limit)
 	}
-	if opt.maxID > 0 {
+	if opt.maxID != "" {
 		limOpts.MaxID = opt.maxID
 	}
-	if opt.sinceID > 0 {
+	if opt.sinceID != "" {
 		limOpts.SinceID = opt.sinceID
 	}
 

--- a/cmd/lists.go
+++ b/cmd/lists.go
@@ -15,8 +15,8 @@ import (
 )
 
 var listsOpts struct {
-	listID     int64
-	accountID  int64
+	listID     madon.ActivityID
+	accountID  madon.ActivityID
 	accountIDs string
 	title      string
 
@@ -51,20 +51,20 @@ func init() {
 	listsCmd.PersistentFlags().UintVarP(&listsOpts.keep, "keep", "k", 0, "Limit number of results")
 	listsCmd.PersistentFlags().BoolVar(&listsOpts.all, "all", false, "Fetch all results")
 
-	listsCmd.PersistentFlags().Int64VarP(&listsOpts.listID, "list-id", "G", 0, "List ID")
+	listsCmd.PersistentFlags().StringVarP(&listsOpts.listID, "list-id", "G", "", "List ID")
 
-	listsGetSubcommand.Flags().Int64VarP(&listsOpts.accountID, "account-id", "a", 0, "Account ID number")
+	listsGetSubcommand.Flags().StringVarP(&listsOpts.accountID, "account-id", "a", "", "Account ID number")
 	// XXX accountUID?
 
-	listsGetAccountsSubcommand.Flags().Int64VarP(&listsOpts.listID, "list-id", "G", 0, "List ID")
+	listsGetAccountsSubcommand.Flags().StringVarP(&listsOpts.listID, "list-id", "G", "", "List ID")
 
 	listsCreateSubcommand.Flags().StringVar(&listsOpts.title, "title", "", "List title")
 	listsUpdateSubcommand.Flags().StringVar(&listsOpts.title, "title", "", "List title")
 
 	listsAddAccountsSubcommand.Flags().StringVar(&listsOpts.accountIDs, "account-ids", "", "Comma-separated list of account IDs")
-	listsAddAccountsSubcommand.Flags().Int64VarP(&listsOpts.accountID, "account-id", "a", 0, "Account ID number")
+	listsAddAccountsSubcommand.Flags().StringVarP(&listsOpts.accountID, "account-id", "a", "", "Account ID number")
 	listsRemoveAccountsSubcommand.Flags().StringVar(&listsOpts.accountIDs, "account-ids", "", "Comma-separated list of account IDs")
-	listsRemoveAccountsSubcommand.Flags().Int64VarP(&listsOpts.accountID, "account-id", "a", 0, "Account ID number")
+	listsRemoveAccountsSubcommand.Flags().StringVarP(&listsOpts.accountID, "account-id", "a", "", "Account ID number")
 }
 
 var listsSubcommands = []*cobra.Command{
@@ -145,7 +145,7 @@ func listsGetRunE(cmd *cobra.Command, args []string) error {
 	var obj interface{}
 	var err error
 
-	if opt.listID > 0 {
+	if opt.listID != "" {
 		var list *madon.List
 		list, err = gClient.GetList(opt.listID)
 		obj = list
@@ -178,7 +178,7 @@ func listsGetRunE(cmd *cobra.Command, args []string) error {
 func listsGetAccountsRunE(cmd *cobra.Command, args []string) error {
 	opt := listsOpts
 
-	if opt.listID <= 0 {
+	if opt.listID == "" {
 		return errors.New("missing list ID")
 	}
 
@@ -237,12 +237,12 @@ func listsSetDeleteRunE(cmd *cobra.Command, args []string) error {
 
 	switch cmd.Name() {
 	case "create":
-		if opt.listID > 0 {
+		if opt.listID != "" {
 			return errors.New("list ID should not be provided with create")
 		}
 		action = actionCreate
 	case "update":
-		if opt.listID <= 0 {
+		if opt.listID == "" {
 			return errors.New("list ID is required")
 		}
 		action = actionUpdate
@@ -300,19 +300,19 @@ func listsSetDeleteRunE(cmd *cobra.Command, args []string) error {
 func listsAddRemoveAccountsRunE(cmd *cobra.Command, args []string) error {
 	opt := listsOpts
 
-	if opt.listID <= 0 {
+	if opt.listID == "" {
 		return errors.New("missing list ID")
 	}
 
-	var ids []int64
+	var ids []madon.ActivityID
 	var err error
 	ids, err = splitIDs(opt.accountIDs)
 	if err != nil {
 		return errors.New("cannot parse account IDs")
 	}
 
-	if opt.accountID > 0 { // Allow --account-id
-		ids = []int64{opt.accountID}
+	if opt.accountID != "" { // Allow --account-id
+		ids = []madon.ActivityID{opt.accountID}
 	}
 	if len(ids) < 1 {
 		return errors.New("missing account IDs")

--- a/cmd/madon.go
+++ b/cmd/madon.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/McKael/madon/v2"
@@ -104,18 +103,16 @@ func madonLogin() error {
 }
 
 // splitIDs splits a list of IDs into an int64 array
-func splitIDs(ids string) (list []int64, err error) {
-	var i int64
+func splitIDs(ids string) (list []madon.ActivityID, err error) {
 	if ids == "" {
 		return
 	}
 	l := strings.Split(ids, ",")
 	for _, s := range l {
-		i, err = strconv.ParseInt(s, 10, 64)
-		if err != nil {
+		if s == "" {
 			return
 		}
-		list = append(list, i)
+		list = append(list, s)
 	}
 	return
 }

--- a/cmd/media.go
+++ b/cmd/media.go
@@ -18,7 +18,7 @@ import (
 var mediaFlags *flag.FlagSet
 
 var mediaOpts struct {
-	mediaID     int64
+	mediaID     madon.ActivityID
 	filePath    string
 	description string
 	focus       string
@@ -48,7 +48,7 @@ func init() {
 	RootCmd.AddCommand(mediaCmd)
 
 	mediaCmd.Flags().StringVar(&mediaOpts.filePath, "file", "", "Path of the media file")
-	mediaCmd.Flags().Int64Var(&mediaOpts.mediaID, "update", 0, "Media to update (ID)")
+	mediaCmd.Flags().StringVar(&mediaOpts.mediaID, "update", "", "Media to update (ID)")
 
 	mediaCmd.Flags().StringVar(&mediaOpts.description, "description", "", "Plain text description")
 	mediaCmd.Flags().StringVar(&mediaOpts.focus, "focus", "", "Focal point")
@@ -61,10 +61,10 @@ func mediaRunE(cmd *cobra.Command, args []string) error {
 	opt := mediaOpts
 
 	if opt.filePath == "" {
-		if opt.mediaID < 1 {
+		if opt.mediaID == "" {
 			return errors.New("no media file name provided")
 		}
-	} else if opt.mediaID > 0 {
+	} else if opt.mediaID != "" {
 		return errors.New("cannot use both --file and --update")
 	}
 
@@ -102,13 +102,13 @@ func mediaRunE(cmd *cobra.Command, args []string) error {
 }
 
 // uploadFile uploads a media file and returns the attachment ID
-func uploadFile(filePath string) (int64, error) {
+func uploadFile(filePath string) (madon.ActivityID, error) {
 	attachment, err := gClient.UploadMedia(filePath, "", "")
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 	if attachment == nil {
-		return 0, nil
+		return "", nil
 	}
 	return attachment.ID, nil
 }

--- a/cmd/suggestions.go
+++ b/cmd/suggestions.go
@@ -15,7 +15,7 @@ import (
 )
 
 var suggestionsOpts struct {
-	accountID  int64
+	accountID  madon.ActivityID
 	accountIDs string
 
 	//limit uint
@@ -41,7 +41,7 @@ func init() {
 	suggestionsGetSubcommand.Flags().UintVarP(&suggestionsOpts.keep, "keep", "k", 0, "Limit number of results")
 	//suggestionsGetSubcommand.Flags().BoolVar(&suggestionsOpts.all, "all", false, "Fetch all results")
 
-	suggestionsDeleteSubcommand.Flags().Int64VarP(&suggestionsOpts.accountID, "account-id", "a", 0, "Account ID number")
+	suggestionsDeleteSubcommand.Flags().StringVarP(&suggestionsOpts.accountID, "account-id", "a", "", "Account ID number")
 	suggestionsDeleteSubcommand.Flags().StringVar(&suggestionsOpts.accountIDs, "account-ids", "", "Comma-separated list of account IDs")
 }
 
@@ -116,13 +116,13 @@ func suggestionsGetRunE(cmd *cobra.Command, args []string) error {
 
 func suggestionsDeleteRunE(cmd *cobra.Command, args []string) error {
 	opt := suggestionsOpts
-	var ids []int64
+	var ids []madon.ActivityID
 	var err error
 
-	if opt.accountID < 1 && len(opt.accountIDs) == 0 {
+	if opt.accountID == "" && len(opt.accountIDs) == 0 {
 		return errors.New("missing account IDs")
 	}
-	if opt.accountID > 0 && len(opt.accountIDs) > 0 {
+	if opt.accountID != "" && len(opt.accountIDs) > 0 {
 		return errors.New("incompatible options")
 	}
 
@@ -130,8 +130,8 @@ func suggestionsDeleteRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.New("cannot parse account IDs")
 	}
-	if opt.accountID > 0 { // Allow --account-id
-		ids = []int64{opt.accountID}
+	if opt.accountID != "" { // Allow --account-id
+		ids = []madon.ActivityID{opt.accountID}
 	}
 	if len(ids) < 1 {
 		return errors.New("missing account IDs")

--- a/cmd/timelines.go
+++ b/cmd/timelines.go
@@ -17,7 +17,7 @@ import (
 var timelineOpts struct {
 	local, onlyMedia bool
 	limit, keep      uint
-	sinceID, maxID   int64
+	sinceID, maxID   madon.ActivityID
 }
 
 // timelineCmd represents the timelines command
@@ -47,25 +47,25 @@ func init() {
 	timelineCmd.Flags().BoolVar(&timelineOpts.onlyMedia, "only-media", false, "Only statuses with media attachments")
 	timelineCmd.Flags().UintVarP(&timelineOpts.limit, "limit", "l", 0, "Limit number of API results")
 	timelineCmd.Flags().UintVarP(&timelineOpts.keep, "keep", "k", 0, "Limit number of results")
-	timelineCmd.PersistentFlags().Int64Var(&timelineOpts.sinceID, "since-id", 0, "Request IDs greater than a value")
-	timelineCmd.PersistentFlags().Int64Var(&timelineOpts.maxID, "max-id", 0, "Request IDs less (or equal) than a value")
+	timelineCmd.PersistentFlags().StringVar(&timelineOpts.sinceID, "since-id", "", "Request IDs greater than a value")
+	timelineCmd.PersistentFlags().StringVar(&timelineOpts.maxID, "max-id", "", "Request IDs less (or equal) than a value")
 }
 
 func timelineRunE(cmd *cobra.Command, args []string) error {
 	opt := timelineOpts
 	var limOpts *madon.LimitParams
 
-	if opt.limit > 0 || opt.sinceID > 0 || opt.maxID > 0 {
+	if opt.limit > 0 || opt.sinceID != "" || opt.maxID != "" {
 		limOpts = new(madon.LimitParams)
 	}
 
 	if opt.limit > 0 {
 		limOpts.Limit = int(opt.limit)
 	}
-	if opt.maxID > 0 {
+	if opt.maxID != "" {
 		limOpts.MaxID = opt.maxID
 	}
-	if opt.sinceID > 0 {
+	if opt.sinceID != "" {
 		limOpts.SinceID = opt.sinceID
 	}
 

--- a/printer/plainprinter.go
+++ b/printer/plainprinter.go
@@ -175,7 +175,7 @@ func (p *PlainPrinter) plainPrintDomainName(d *madon.DomainName, w io.Writer, in
 }
 
 func (p *PlainPrinter) plainPrintAccount(a *madon.Account, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "Account ID", "%d (%s)", a.ID, a.Username)
+	indentedPrint(w, indent, true, false, "Account ID", "%s (%s)", a.ID, a.Username)
 	indentedPrint(w, indent, false, false, "User ID", "%s", a.Acct)
 	indentedPrint(w, indent, false, false, "Display name", "%s", a.DisplayName)
 	indentedPrint(w, indent, false, false, "Creation date", "%v", a.CreatedAt.Local())
@@ -192,7 +192,7 @@ func (p *PlainPrinter) plainPrintAccount(a *madon.Account, w io.Writer, indent s
 	indentedPrint(w, indent, false, true, "User note", "%s", html2string(a.Note)) // XXX too long?
 	if a.Moved != nil {
 		m := a.Moved
-		indentedPrint(w, indent+p.Indent, true, false, "Moved to account ID", "%d (%s)", m.ID, m.Username)
+		indentedPrint(w, indent+p.Indent, true, false, "Moved to account ID", "%s (%s)", m.ID, m.Username)
 		indentedPrint(w, indent+p.Indent, false, false, "New user ID", "%s", m.Acct)
 		indentedPrint(w, indent+p.Indent, false, false, "New display name", "%s", m.DisplayName)
 	}
@@ -218,7 +218,7 @@ func (p *PlainPrinter) plainPrintAccount(a *madon.Account, w io.Writer, indent s
 }
 
 func (p *PlainPrinter) plainPrintAttachment(a *madon.Attachment, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "Attachment ID", "%d", a.ID)
+	indentedPrint(w, indent, true, false, "Attachment ID", "%s", a.ID)
 	indentedPrint(w, indent, false, false, "Type", "%s", a.Type)
 	indentedPrint(w, indent, false, false, "Local URL", "%s", a.URL)
 	if a.RemoteURL != nil {
@@ -269,7 +269,7 @@ func (p *PlainPrinter) plainPrintInstance(i *madon.Instance, w io.Writer, indent
 	indentedPrint(w, indent, false, true, "Version", "%s", i.Version)
 	if i.ContactAccount != nil {
 		c := i.ContactAccount
-		indentedPrint(w, indent+p.Indent, true, false, "Contact account ID", "%d (%s)", c.ID, c.Username)
+		indentedPrint(w, indent+p.Indent, true, false, "Contact account ID", "%s (%s)", c.ID, c.Username)
 		indentedPrint(w, indent+p.Indent, false, false, "Contact user ID", "%s", c.Acct)
 		indentedPrint(w, indent+p.Indent, false, false, "Contact display name", "%s", c.DisplayName)
 	}
@@ -282,17 +282,17 @@ func (p *PlainPrinter) plainPrintInstancePeer(i *madon.InstancePeer, w io.Writer
 }
 
 func (p *PlainPrinter) plainPrintList(l *madon.List, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "List ID", "%d", l.ID)
+	indentedPrint(w, indent, true, false, "List ID", "%s", l.ID)
 	indentedPrint(w, indent, false, false, "Title", "%s", l.Title)
 	return nil
 }
 
 func (p *PlainPrinter) plainPrintNotification(n *madon.Notification, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "Notification ID", "%d", n.ID)
+	indentedPrint(w, indent, true, false, "Notification ID", "%s", n.ID)
 	indentedPrint(w, indent, false, false, "Type", "%s", n.Type)
 	indentedPrint(w, indent, false, false, "Timestamp", "%v", n.CreatedAt.Local())
 	if n.Account != nil {
-		indentedPrint(w, indent+p.Indent, true, false, "Account", "(%d) @%s - %s",
+		indentedPrint(w, indent+p.Indent, true, false, "Account", "(%s) @%s - %s",
 			n.Account.ID, n.Account.Acct, n.Account.DisplayName)
 	}
 	if n.Status != nil {
@@ -302,7 +302,7 @@ func (p *PlainPrinter) plainPrintNotification(n *madon.Notification, w io.Writer
 }
 
 func (p *PlainPrinter) plainPrintRelationship(r *madon.Relationship, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "Account ID", "%d", r.ID)
+	indentedPrint(w, indent, true, false, "Account ID", "%s", r.ID)
 	indentedPrint(w, indent, false, false, "Following", "%v", r.Following)
 	//indentedPrint(w, indent, false, false, "Showing reblogs", "%v", r.ShowingReblogs)
 	indentedPrint(w, indent, false, false, "Followed-by", "%v", r.FollowedBy)
@@ -315,7 +315,7 @@ func (p *PlainPrinter) plainPrintRelationship(r *madon.Relationship, w io.Writer
 }
 
 func (p *PlainPrinter) plainPrintReport(r *madon.Report, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "Report ID", "%d", r.ID)
+	indentedPrint(w, indent, true, false, "Report ID", "%s", r.ID)
 	indentedPrint(w, indent, false, false, "Action taken", "%s", r.ActionTaken)
 	return nil
 }
@@ -342,7 +342,7 @@ func (p *PlainPrinter) plainPrintResults(r *madon.Results, w io.Writer, indent s
 }
 
 func (p *PlainPrinter) plainPrintStatus(s *madon.Status, w io.Writer, indent string) error {
-	indentedPrint(w, indent, true, false, "Status ID", "%d", s.ID)
+	indentedPrint(w, indent, true, false, "Status ID", "%s", s.ID)
 	if s.Account != nil {
 		author := s.Account.Acct
 		if s.Account.DisplayName != "" {
@@ -370,8 +370,8 @@ func (p *PlainPrinter) plainPrintStatus(s *madon.Status, w io.Writer, indent str
 	}
 
 	indentedPrint(w, indent, false, false, "Contents", "%s", html2string(s.Content))
-	if s.InReplyToID != nil && *s.InReplyToID > 0 {
-		indentedPrint(w, indent, false, false, "In-Reply-To", "%d", *s.InReplyToID)
+	if s.InReplyToID != nil && *s.InReplyToID != "" {
+		indentedPrint(w, indent, false, false, "In-Reply-To", "%s", *s.InReplyToID)
 	}
 	if s.Reblogged {
 		indentedPrint(w, indent, false, false, "Reblogged", "%v", s.Reblogged)
@@ -380,7 +380,7 @@ func (p *PlainPrinter) plainPrintStatus(s *madon.Status, w io.Writer, indent str
 	// Display minimum details of attachments
 	//return p.PrintObj(s.MediaAttachments, w, indent+p.Indent)
 	for _, a := range s.MediaAttachments {
-		indentedPrint(w, indent+p.Indent, true, false, "Attachment ID", "%d", a.ID)
+		indentedPrint(w, indent+p.Indent, true, false, "Attachment ID", "%s", a.ID)
 		if a.TextURL != nil && *a.TextURL != "" {
 			indentedPrint(w, indent+p.Indent, true, false, "Text URL", "%s", *a.TextURL)
 		} else if a.URL != "" {


### PR DESCRIPTION
NB: Requires the corresponding `madon` PR to be applied first since this relies on `madon` as a library

Pleroma/Akkoma and GotoSocial use opaque IDs rather than `int64`s like Mastodon which means that `madon` can't talk to either of those.

This commit updates everything that can be an ID to `madon.ActivityID` which is an alias for `string` - can't create a specific type for it since there's more than a few places where they're concatenated directly to strings for URLs, etc. Which means it could just as easily be a direct `string` type itself but I find that having distinct types can often make the code more readable and understandable.

One extra bit is that `statusOpts` has grown a `_hasReplyTo` boolean to indicate whether the `--in-reply-to` flag was given or not because we can't distinguish because "empty because default" or "empty because given and empty".  Another way around this would be to set the default to some theoretically impossible or unlikely string but you never know when someone might spin up an instance where, e.g., admin posts have negative integer IDs.